### PR TITLE
Add cache-control headers for images

### DIFF
--- a/app/_components/layout/layout.module.css
+++ b/app/_components/layout/layout.module.css
@@ -3,7 +3,7 @@
   background:
     linear-gradient(transparent 40vh, var(--color-theme) 50vh),
     top left / contain no-repeat
-      url('/images/bg/background-narrow-2-med.jpg?v1');
+      url('/images/bg/background-narrow-2-med.jpg?v=1');
 }
 
 @media screen and (min-width: 768px) {
@@ -11,20 +11,20 @@
     background:
       linear-gradient(transparent 50vh, var(--color-theme) 80vh),
       top left / contain no-repeat
-        url('/images/bg/background-narrow-1-med.jpg?v1');
+        url('/images/bg/background-narrow-1-med.jpg?v=1');
   }
 }
 
 @media screen and (min-width: 1025px) {
   .page {
     background: fixed left center / cover no-repeat
-      url('/images/bg/background-med.jpg?v1');
+      url('/images/bg/background-med.jpg?v=1');
   }
 }
 
 @media screen and (min-width: 2200px) {
   .page {
     background: fixed left center / cover no-repeat
-      url('/images/bg/background-high.jpg?v1');
+      url('/images/bg/background-high.jpg?v=1');
   }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -6,10 +6,17 @@ const nextConfig = {
     return [
       {
         source: '/images/:path*(svg|jpg|png|webp)',
-        locale: false,
+        has: [
+          {
+            type: 'query',
+            key: 'v',
+            value: '([0-9]+)',
+          },
+        ],
         headers: [
           {
             key: 'Cache-Control',
+            // day * 86400 = seconds. e.g., 2592000 = 30 days
             value: 'public, max-age=2592000, immutable',
           },
         ],


### PR DESCRIPTION
Add a cache-control header for images with a `v` querystring value,
for example `/images/bg.png?v=1`. This doesn't apply to statically
imported images used with `next/image`.